### PR TITLE
Allow passing "options" to DocumentParameters.setItem 

### DIFF
--- a/lib/DocumentParameters.js
+++ b/lib/DocumentParameters.js
@@ -31,7 +31,7 @@ var RosetteException = require("./RosetteException");
  * @throws RosetteException
  */
 function DocumentParameters() {
-  DocumentParamSetBase.call(this, ["content", "contentUri", "contentType", "unit", "language"]); //super constructor
+  DocumentParamSetBase.call(this, ["content", "contentUri", "contentType", "unit", "language", "options"]); //super constructor
   this.setItem("unit", rosetteConstants.inputUnit.DOC);
 }
 


### PR DESCRIPTION
This is needed by the sentiment analysis API to supply the content model parameter and to ask for analysis explanation.

As in:
    var docParams = new DocumentParameters();
    docParams.setItem('content', text);
    var options = { explain: true };
    docParams.setItem('options', options);
