### PR TITLE
Updated to reuse HTTP(S) client

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -15,6 +15,7 @@
 
 var http = require("http");
 var https = require("https");
+var URL = require("url");
 
 var rosetteConstants = require("./rosetteConstants");
 var RosetteException = require("./rosetteExceptions");
@@ -78,7 +79,8 @@ function Api(userKey, serviceURL) {
     } else {
         this.serviceURL = "https://api.rosette.com/rest/v1/";
     }
-    if (serviceURL.protocol === "http:") {
+    var urlParts = URL.parse(serviceURL);
+    if (urlParts.protocol === "http:") {
         this.protocol = http;
     }
 

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -13,6 +13,9 @@
  **/
 "use strict";
 
+var http = require("http");
+var https = require("https");
+
 var rosetteConstants = require("./rosetteConstants");
 var RosetteException = require("./rosetteExceptions");
 var paramObj = require("./parameters");
@@ -55,6 +58,12 @@ function Api(userKey, serviceURL) {
     this.parameters = new paramObj();
 
     /**
+     * @type {object}
+     * @desc The HTTP(S) object
+     */
+    this.protocol = https;
+
+    /**
      * @type {string}
      * @desc URL of the API
      * @default
@@ -68,6 +77,9 @@ function Api(userKey, serviceURL) {
         }
     } else {
         this.serviceURL = "https://api.rosette.com/rest/v1/";
+    }
+    if (serviceURL.protocol === "http:") {
+        this.protocol = http;
     }
 
 };
@@ -84,7 +96,7 @@ Api.prototype.rosette = function(endpoint, callback) {
     var e = new endpoint();
 
             // send parameters to the specified endpoint
-    e.getResults(api.parameters, api.userKey, api.serviceURL, function(err, res) {
+    e.getResults(api.parameters, api.userKey, api.protocol, api.serviceURL, function(err, res) {
         if (err) {
             return callback(err);
         } else {

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -36,10 +36,10 @@ function categories() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-categories.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+categories.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     if (parameters.documentFile != null) {
-        parameters.loadFile(parameters.documentFile, parameters, userKey, serviceURL, "categories", callback);
+        parameters.loadFile(parameters.documentFile, parameters, userKey, protocol, serviceURL, "categories", callback);
     } else {
 
     // validate parameters
@@ -51,7 +51,7 @@ categories.prototype.getResults = function(parameters, userKey, serviceURL, call
             // configure URL
             var urlParts = URL.parse(serviceURL + "categories");
             var req = new rosetteRequest();
-            req.makeRequest('POST', userKey, urlParts, parameters, callback);
+            req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
         }
     }
 

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -36,14 +36,14 @@ function entities() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-entities.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+entities.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     if (parameters.documentFile != null) {
         if (parameters.loadParams().linked == true) {
             console.warn("entities/linked endpoint has been combined with /entities. Do not specify the linked parameter.");
-            parameters.loadFile(parameters.loadParams().documentFile, parameters, userKey, serviceURL, "entities/linked", callback);
+            parameters.loadFile(parameters.loadParams().documentFile, parameters, userKey, protocol, serviceURL, "entities/linked", callback);
         } else {
-            parameters.loadFile(parameters.loadParams().documentFile, parameters, userKey, serviceURL, "entities", callback);
+            parameters.loadFile(parameters.loadParams().documentFile, parameters, userKey, protocol, serviceURL, "entities", callback);
         }
         
 
@@ -66,7 +66,7 @@ entities.prototype.getResults = function(parameters, userKey, serviceURL, callba
 
             
             var req = new rosetteRequest();
-            req.makeRequest('POST', userKey, urlParts, parameters, callback);
+            req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
             
         }
     }

--- a/lib/info.js
+++ b/lib/info.js
@@ -36,12 +36,12 @@ function info() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-info.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+info.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     // configure URL
     var urlParts = URL.parse(serviceURL + "info");
     var req = new rosetteRequest();
-    req.makeRequest('GET', userKey, urlParts, parameters, callback);
+    req.makeRequest('GET', userKey, protocol, urlParts, parameters, callback);
 };
 
 module.exports = info;

--- a/lib/language.js
+++ b/lib/language.js
@@ -36,10 +36,10 @@ function language() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-language.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+language.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     if (parameters.documentFile != null) {
-        parameters.loadFile(parameters.documentFile, parameters, userKey, serviceURL, "language", callback);
+        parameters.loadFile(parameters.documentFile, parameters, userKey, protocol, serviceURL, "language", callback);
     } else {
 
         // validate parameters
@@ -51,7 +51,7 @@ language.prototype.getResults = function(parameters, userKey, serviceURL, callba
             // configure URL
             var urlParts = URL.parse(serviceURL + "language");
             var req = new rosetteRequest();
-            req.makeRequest('POST', userKey, urlParts, parameters, callback);
+            req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
         }
     }
 

--- a/lib/morphology.js
+++ b/lib/morphology.js
@@ -36,10 +36,10 @@ function morphology() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-morphology.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+morphology.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
     //console.log(parameters)
     if (parameters.documentFile != null) {
-        parameters.loadFile(parameters.documentFile, parameters, userKey, serviceURL, "morphology" + "/" + parameters.morphology, callback);
+        parameters.loadFile(parameters.documentFile, parameters, userKey, protocol, serviceURL, "morphology" + "/" + parameters.morphology, callback);
     } else {
 
         // validate parameters
@@ -53,7 +53,7 @@ morphology.prototype.getResults = function(parameters, userKey, serviceURL, call
             // configure URL
             var urlParts = URL.parse(serviceURL + "morphology" + "/" + parameters.morphology);
             var req = new rosetteRequest();
-            req.makeRequest('POST', userKey, urlParts, parameters, callback);
+            req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
         }
     }
 

--- a/lib/nameSimilarity.js
+++ b/lib/nameSimilarity.js
@@ -36,10 +36,10 @@ function nameSimilarity() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-nameSimilarity.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+nameSimilarity.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     if (parameters.documentFile != null) {
-        parameters.loadFile(parameters.documentFile, parameters, userKey, serviceURL, "name-similarity", callback);
+        parameters.loadFile(parameters.documentFile, parameters, userKey, protocol, serviceURL, "name-similarity", callback);
     } else {
 
         // validate parameters
@@ -49,7 +49,7 @@ nameSimilarity.prototype.getResults = function(parameters, userKey, serviceURL, 
             // configure URL
             var urlParts = URL.parse(serviceURL + "name-similarity");
             var req = new rosetteRequest();
-            req.makeRequest('POST', userKey, urlParts, parameters, callback);
+            req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
         }
     }
 

--- a/lib/nameTranslation.js
+++ b/lib/nameTranslation.js
@@ -36,10 +36,10 @@ function nameTranslation() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-nameTranslation.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+nameTranslation.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     if (parameters.documentFile != null) {
-        parameters.loadFile(parameters.documentFile, parameters, userKey, serviceURL, "name-translation", callback);
+        parameters.loadFile(parameters.documentFile, parameters, userKey, protocol, serviceURL, "name-translation", callback);
     } else {
 
         // validate parameters
@@ -51,7 +51,7 @@ nameTranslation.prototype.getResults = function(parameters, userKey, serviceURL,
             // configure URL
             var urlParts = URL.parse(serviceURL + "name-translation");
             var req = new rosetteRequest();
-            req.makeRequest('POST', userKey, urlParts, parameters, callback);
+            req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
         }
     }
 

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -120,7 +120,7 @@ parameters.prototype.loadParams = function() {
  * Reads a file and sets the content, and unit parameters accordingly
  *@param {file} filePath - The file path from which the desired file will be loaded
  */
-parameters.prototype.loadFile = function(filePath, loadedParameters, userKey, serviceURL, endpoint, callback) {
+parameters.prototype.loadFile = function(filePath, loadedParameters, userKey, protocol, serviceURL, endpoint, callback) {
     var str = fs.readFileSync(filePath, "utf8");
     var mp = new Multipart()
 
@@ -146,10 +146,6 @@ parameters.prototype.loadFile = function(filePath, loadedParameters, userKey, se
     }).on('end', function() {
 
         var urlParts = URL.parse(serviceURL + endpoint);
-        var protocol = https;
-        if (urlParts.protocol === "http:") {
-            protocol = http;
-        }
 
         var headers = {
             "accept": 'application/json',

--- a/lib/ping.js
+++ b/lib/ping.js
@@ -36,7 +36,7 @@ function ping() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-ping.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+ping.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     // configure URL
     var urlParts = URL.parse(serviceURL + "ping");

--- a/lib/ping.js
+++ b/lib/ping.js
@@ -41,7 +41,7 @@ ping.prototype.getResults = function(parameters, userKey, serviceURL, callback) 
     // configure URL
     var urlParts = URL.parse(serviceURL + "ping");
     var req = new rosetteRequest();
-    req.makeRequest('GET', userKey, urlParts, parameters, callback);
+    req.makeRequest('GET', userKey, protocol, urlParts, parameters, callback);
 };
 
 module.exports = ping;

--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -36,10 +36,10 @@ function relationships() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-relationships.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+relationships.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     if (parameters.documentFile != null) {
-        parameters.loadFile(parameters.documentFile, parameters, userKey, serviceURL, "relationships", callback);
+        parameters.loadFile(parameters.documentFile, parameters, userKey, protocol, serviceURL, "relationships", callback);
     } else {
 
         // validate parameters
@@ -52,7 +52,7 @@ relationships.prototype.getResults = function(parameters, userKey, serviceURL, c
         // configure URL
         var urlParts = URL.parse(serviceURL + "relationships");
         var req = new rosetteRequest();
-        req.makeRequest('POST', userKey, urlParts, parameters, callback);
+        req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
     }
 
 };

--- a/lib/rosetteRequest.js
+++ b/lib/rosetteRequest.js
@@ -49,8 +49,6 @@ rosetteRequest.prototype.bindingVersion = function() { return BINDING_VERSION; }
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
 rosetteRequest.prototype.makeRequest = function(requestType, userKey, protocol, urlParts, parameters, callback) {
-    protocol = https;
-
     var maxRetries = 5;
     var interval = 500;
 

--- a/lib/rosetteRequest.js
+++ b/lib/rosetteRequest.js
@@ -49,6 +49,8 @@ rosetteRequest.prototype.bindingVersion = function() { return BINDING_VERSION; }
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
 rosetteRequest.prototype.makeRequest = function(requestType, userKey, protocol, urlParts, parameters, callback) {
+    protocol = https;
+
     var maxRetries = 5;
     var interval = 500;
 

--- a/lib/rosetteRequest.js
+++ b/lib/rosetteRequest.js
@@ -48,13 +48,7 @@ rosetteRequest.prototype.bindingVersion = function() { return BINDING_VERSION; }
  * @param {object} parameters - Structure containing the API parameters
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-rosetteRequest.prototype.makeRequest = function(requestType, userKey, urlParts, parameters, callback) {
-    // configure URL
-    var protocol = https;
-    if (urlParts.protocol === "http:") {
-        protocol = http;
-    }
-
+rosetteRequest.prototype.makeRequest = function(requestType, userKey, protocol, urlParts, parameters, callback) {
     var maxRetries = 5;
     var interval = 500;
 

--- a/lib/sentences.js
+++ b/lib/sentences.js
@@ -36,10 +36,10 @@ function sentences() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-sentences.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+sentences.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     if (parameters.documentFile != null) {
-        parameters.loadFile(parameters.documentFile, parameters, userKey, serviceURL, "sentences", callback);
+        parameters.loadFile(parameters.documentFile, parameters, userKey, protocol, serviceURL, "sentences", callback);
     } else {
 
         // validate parameters
@@ -51,7 +51,7 @@ sentences.prototype.getResults = function(parameters, userKey, serviceURL, callb
             // configure URL
             var urlParts = URL.parse(serviceURL + "sentences");
             var req = new rosetteRequest();
-            req.makeRequest('POST', userKey, urlParts, parameters, callback);
+            req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
         }
     }
 

--- a/lib/sentiment.js
+++ b/lib/sentiment.js
@@ -36,10 +36,10 @@ function sentiment() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-sentiment.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+sentiment.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     if (parameters.documentFile != null) {
-        parameters.loadFile(parameters.documentFile, parameters, userKey, serviceURL, "sentiment", callback);
+        parameters.loadFile(parameters.documentFile, parameters, userKey, protocol, serviceURL, "sentiment", callback);
     } else {
 
         // validate parameters
@@ -52,7 +52,7 @@ sentiment.prototype.getResults = function(parameters, userKey, serviceURL, callb
             // configure URL
             var urlParts = URL.parse(serviceURL + "sentiment");
             var req = new rosetteRequest();
-            req.makeRequest('POST', userKey, urlParts, parameters, callback);
+            req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
         }
     }
 };

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -36,10 +36,10 @@ function tokens() {
  * @param {string} serviceURL - The base service URL to be used to access the Rosette API
  * @param {function} callback - Callback function to be exectuted after the function to which it is passed is complete
  */
-tokens.prototype.getResults = function(parameters, userKey, serviceURL, callback) {
+tokens.prototype.getResults = function(parameters, userKey, protocol, serviceURL, callback) {
 
     if (parameters.documentFile != null) {
-        parameters.loadFile(parameters.documentFile, parameters, userKey, serviceURL, "tokens", callback);
+        parameters.loadFile(parameters.documentFile, parameters, userKey, protocol, serviceURL, "tokens", callback);
     } else {
 
         // validate parameters
@@ -51,7 +51,7 @@ tokens.prototype.getResults = function(parameters, userKey, serviceURL, callback
             // configure URL
             var urlParts = URL.parse(serviceURL + "tokens");
             var req = new rosetteRequest();
-            req.makeRequest('POST', userKey, urlParts, parameters, callback);
+            req.makeRequest('POST', userKey, protocol, urlParts, parameters, callback);
         }
     }
 


### PR DESCRIPTION
- Moved the http(s) creation to the Api object
- http(s) "protocol" object passed through to rosetteRequest
- rosetteRequest and parameters (multi-part) modified to use the passed in protocol
- unit tests pass
